### PR TITLE
Repair vega-cft-mpa-voperate_sku.yaml

### DIFF
--- a/latest/aws/vega-cft-mpa-voperate_sku.yaml
+++ b/latest/aws/vega-cft-mpa-voperate_sku.yaml
@@ -56,12 +56,12 @@ Resources:
               - "compute-optimizer:Get*"
             Effect: "Allow"  
             Resource: "*"
-          - Sid: VegaDiscoveryEC2
+          - Sid: VegaDiscoverySavingsPlans
             Action:
               - "savingsplans:*"
             Effect: Allow
             Resource: "*"
-          - Sid: VegaDiscoveryEC2
+          - Sid: VegaDiscoveryOrganizations
             Action:
               - "organizations:Describe*"
               - "organizations:List*"


### PR DESCRIPTION
This is break-fix.  CFT will not deploy as-is due to non-unique SID.