### PR TITLE
GCP Role Creation yaml description update

### DIFF
--- a/latest/gcp/gcp-vega-admin-role.yml
+++ b/latest/gcp/gcp-vega-admin-role.yml
@@ -1,21 +1,9 @@
 ---
 title: Vega Platform Least Privilege Integration Role
 description: >
-  Access to discover & read billing, bigquery, and other reporting
-  resources. Includes the  compute.projects.setUsageExportBucket permission for
-  automated setup. Also includes bigquery.readsessions.create to stream large
-  billing data datasets. Please enable the following apis before proceeding:
-  
-    Google Compute Engine API
-    Google Cloud Storage API
-    Google Cloud Resource Manager API
-    Google Cloud Storage JSON API
-    BigQuery API
-    BigQuery Storage API
-    Cloud Billing API
-    Dataproc API
-    Kubernetes Engine API
-    Recommender API
+  Access to discover & read billing data, BigQuery, and other reporting
+  resources. Please visit https://docs.vegacloud.io/docs/providers/gcp
+  for a list of the APIs that need to be enabled.
     
 stage: GA
 includedPermissions:

--- a/latest/gcp/gcp-voperate-parking-perms.yaml
+++ b/latest/gcp/gcp-voperate-parking-perms.yaml
@@ -1,22 +1,9 @@
 ---
 title: Vega Platform Integration Role - Parking Perms
 description: >
-  Access to discover & read billing, bigquery, and other reporting
-  resources. Includes the  compute.projects.setUsageExportBucket permission for
-  automated setup. Also includes bigquery.readsessions.create to stream large
-  billing data datasets. Please enable the following apis before proceeding:
-  
-    Google Compute Engine API
-    Google Cloud Storage API
-    Google Cloud Resource Manager API
-    Google Cloud Storage JSON API
-    Google Cloud SQL Admin API
-    BigQuery API
-    BigQuery Storage API
-    Cloud Billing APIDataproc API
-    Cloud SQL Admin API
-    Kubernetes Engine API
-    Recommender API
+  Access to discover & read billing data, BigQuery, and other reporting
+  resources. Please visit https://docs.vegacloud.io/docs/providers/gcp
+  for a list of the APIs that need to be enabled.
     
 stage: GA
 includedPermissions:


### PR DESCRIPTION
Modified description of permissions yaml files as their current configurations exceed the 300 character limit in GCP and error out upon attempting to create custom role