### PR TITLE
Hotfix: Bucket Name Collision

### DIFF
--- a/latest/gcp/gcp-billing-resources.jinja
+++ b/latest/gcp/gcp-billing-resources.jinja
@@ -18,12 +18,9 @@ resources:
     access:
     - role: roles/bigquery.dataViewer
       userByEmail: $(ref.vega-billing-service-account-{{ env["project_number"] }}.email)
-    tags: []
-    labels: {}
-- name: vega-billing-export-bucket
+- name: "vega-billing-export-{{ env["project_number"] }}"
   type: storage.v1.bucket
   properties:
-    name: "vega-billing-export-{{ env["project_number"] }}"
     location: US
     storageClass: STANDARD
     predefinedAcl: projectPrivate
@@ -34,7 +31,6 @@ resources:
             type: Delete
           condition:
             age: 30
-    labels: {}
   accessControl:
     gcpIamPolicy:
       bindings:
@@ -52,4 +48,4 @@ outputs:
 - name: vega-billing-service-account
   value: $(ref.vega-billing-service-account-{{ env["project_number"] }}.email)
 - name: vega-cloud-storage-export-bucket
-  value: $(ref.vega-billing-export-bucket.name)
+  value: $(ref.vega-billing-export-{{ env["project_number"] }}.name)


### PR DESCRIPTION
- removed `storage.v1.bucket`'s `properties.name` attribute as it isnot used by Deployment Manager
- templated `storage.v1.bucket`'s top-level attribute `name` to generate unique GCP Storage Bucket names
- updated the output referencing the `storage.v1.bucket` resource block to mirror the templating used to define the resource's name
- removed unused tag and label attributes